### PR TITLE
Updating Travis ci dist to xenial (instead of trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 dist: xenial
+sudo: required
 
 before_install:
   - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: xenial
 
 before_install:
   - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y


### PR DESCRIPTION
Updating travis ci dist to xenial (instead of trusty). Trusty does not use cmake 3, and is about to be retired.