### PR TITLE
Add ENABLE_LANGUAGE(C) to CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+#### Enable C Language
+ENABLE_LANGUAGE(C)
+
 # Enable stack-unwinding support in c objects on gcc-based platforms.
 # Failing to do so will cause your program to be terminated when a png
 # or a jpeg exception is thrown on linux or macosx.


### PR DESCRIPTION
Without this line, builds fail on Linux and Mac