### PR TITLE
Travis CI: Also run `make install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - mkdir -p build; cd build;
   - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
   - make VERBOSE=1
+  - make install DESTDIR=dist/
 
 notifications:
   email: true


### PR DESCRIPTION
As in OpenShot/libopenshot#223, run the install step after build (with `DESTDIR=dist/`) to exercise more of the build tooling.