### PR TITLE
Fix Python3 discovery, add docs install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,24 +218,39 @@ INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/openshot-audio-test-sound.1
 	DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 )
 
 ########### DOCUMENTATION ##########
-# Pre-process the sources to fix documentation formatting
-add_custom_target(process-source-files
-	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/doc/process_source_files.py ${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules "docs"
-	COMMENT "Processing source code for documentation"
-	VERBATIM )
+# We need Python to process the source for Doxygen...
+find_package(PythonInterp 3)
 
-# Processed docs are removed on "make clean"
-set_property(DIRECTORY APPEND
-	PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-       	"docs" )
+if(PYTHONINTERP_FOUND)
+	# Pre-process the sources to fix documentation formatting
+	add_custom_target(process-source-files
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doc/process_source_files.py ${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules "docs"
+		COMMENT "Formatting source code for documentation"
+		VERBATIM )
 
-# Find Doxygen (used for documentation)
-include(cmake/Modules/UseDoxygen.cmake)
+	# Processed docs are removed on "make clean"
+	set_property(DIRECTORY APPEND PROPERTY
+		ADDITIONAL_MAKE_CLEAN_FILES "docs" )
 
-# Make sure process-source comes before both other targets
-if(TARGET doc)
-	add_dependencies(doc process-source-files)
-endif()
-if(TARGET doxygen)
-	add_dependencies(doxygen process-source-files)
+	# Find Doxygen (used for documentation)
+	include(cmake/Modules/UseDoxygen.cmake)
+
+	# Make sure process-source comes before Doxygen targets,
+	# assuming UseDoxygen found the tools and created them
+	if(TARGET doc)
+		add_dependencies(doc process-source-files)
+	endif()
+	if(TARGET doxygen)
+		add_dependencies(doxygen process-source-files)
+	endif()
+	
+	# Install docs, if the user builds them with `make doc`
+	install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
+	install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Python3 and Doxygen)\")")
+	
+	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
+		DESTINATION ${CMAKE_INSTALL_DOCDIR}
+		MESSAGE_NEVER # Don't spew about file copies
+		OPTIONAL )    # No error if the docs aren't found
+		
 endif()


### PR DESCRIPTION
CMake will now discover for Python 3 in addition to Doxygen, as a
prerequisite for creating a `doc` target. If everything checks out,
the user can run `make doc` to generate formatted docs, and they
will be installed to `${CMAKE_INSTALL_DOCDIR}` (typically
`${CMAKE_INSTALL_PREFIX}/share/doc/libopenshot/audio/`) when
`make install` is run.