### PR TITLE
Change installation directory for docs to DOCDIR/API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if(PYTHONINTERP_FOUND)
 	install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Python3 and Doxygen)\")")
 	
 	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
-		DESTINATION ${CMAKE_INSTALL_DOCDIR}
+		DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
 		MESSAGE_NEVER # Don't spew about file copies
 		OPTIONAL )    # No error if the docs aren't found
 		


### PR DESCRIPTION
This moves the installation target directory for the documentation files to `${CMAKE_INSTALL_DOCDIR}/API`, which on most systems is `${CMAKE_INSTALL_PREFIX}/share/doc/libopenshot-audio/API`. 

(The API docs are hundreds of HTML files, so I figured it was better to keep them contained in a subdir. They were previously all being dumped into `${CMAKE_INSTALL_PREFIX}/share/doc/libopenshot-audio/`)