### PR TITLE
Travis: add MacOS building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,35 @@
 language: cpp
-dist: xenial
-sudo: required
+
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    - os: osx
+
+addons:
+  apt:
+    packages:
+      - cmake
+      - swig
+      - libasound2-dev
+      - libunittest++-dev
+      - doxygen
+      - graphviz
 
 before_install:
-  - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-  - sudo apt-get update -qq
-  - sudo apt-get install gcc-4.8 cmake libopenshot-audio-dev libunittest++-dev swig libasound2-dev -y
-  - sudo apt autoremove -y
   - pwd
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew update
+      brew install swig unittest-cpp doxygen
+    fi
 
 script:
   - mkdir -p build; cd build;
-  - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$TRAVIS_OS_NAME-x64" -DCMAKE_BUILD_TYPE:STRING="Debug" ../
   - make VERBOSE=1
-  - make install DESTDIR=dist/
+  - make doc
+  - make install
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,18 @@ addons:
       - doxygen
       - graphviz
 
-before_install:
-  - pwd
-  - |
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      brew update
-      brew install swig unittest-cpp doxygen
-    fi
+  homebrew:
+    update: true
+    packages:
+      - gcc
+      - unittest-cpp
+      - swig
 
 script:
   - mkdir -p build; cd build;
   - cmake -DCMAKE_INSTALL_PREFIX:PATH="$TRAVIS_OS_NAME-x64" -DCMAKE_BUILD_TYPE:STRING="Debug" ../
   - make VERBOSE=1
-  - make doc
+  - if [ $TRAVIS_OS_NAME = linux ]; then make doc; fi
   - make install
 
 notifications:


### PR DESCRIPTION
This adds a MacOS build (`os: osx`) to the Travis build matrix, alongside the existing Linux build. Each build will be carried out on both platforms simultaneously.

It also:
- Uses Travis' apt addon to install packages, rather than `sudo apt-get`
  (MacOS packages are installed using `brew install` commands)
- No longer installs the libopenshot-audio PPA or the libopenshot-audio-dev package prior to building the source tree
- Installs doxygen (and graphviz on Linux)
- Runs `make doc` before `make install`
- Uses `CMAKE_INSTALL_PREFIX` instead of `make DESTDIR`