### PR TITLE
MathsFunctions.h: include math.h for isfinite()

### DIFF
--- a/JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h
@@ -23,6 +23,8 @@
 namespace juce
 {
 
+/** needed for std::isfinite() */
+#include <math.h>
 //==============================================================================
 /*
     This file sets up some handy mathematical typdefs and functions.


### PR DESCRIPTION
Using std::isfinite() requires including `<cmath>`, though I have written it here as `<math.h>`, as it is used elsewhere in the tree. Resolves the following problem when compiling libopenshot on Debian Unstable:

```
In file included from /usr/local/include/libopenshot-audio/modules/juce_audio_basics/../juce_core/juce_core.h:175:
/usr/local/include/libopenshot-audio/modules/juce_audio_basics/../juce_core/maths/juce_MathsFunctions.h:394:12: error: 
      no member named 'finite' in namespace 'std'; did you mean simply 'finite'?
    return std::isfinite (value);
           ^~~~~
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:182:19: note: 'finite' declared
      here
__MATHDECL_1 (int,finite,, (_Mdouble_ __value)) __attribute__ ((__const__));
                  ^
17 warnings and 2 errors generated.

```