### PR TITLE
Kernel32.dll must come after Winmm.dll (or else)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,12 +101,15 @@ IF (WIN32)
 
 	ADD_DEFINITIONS(-DJUCE_DONT_AUTOLINK_TO_WIN32_LIBRARIES)
 
+	# winmm.lib must come before kernel (or older version of 32-bit windows
+	# will have linking issues for certain entry points)
 	SET(JUCE_PLATFORM_SPECIFIC_LIBRARIES
 		advapi32.lib
 		comdlg32.lib
 		gdi32.lib
 		GlU32.lib
 		Imm32.dll
+		winmm.lib
 		kernel32.lib
 		ole32.lib
 		OpenGL32.lib
@@ -116,7 +119,6 @@ IF (WIN32)
 		user32.lib
 		vfw32.lib
 		version.lib
-		winmm.lib
 		wininet.lib
 		ws2_32.lib
 		)


### PR DESCRIPTION
Fixing order of windows link commands (hopefully). Kernel32.dll must come after Winmm.dll, or older versions of 32-bit windows will fail to find certain symbols. Newer versions of Kernel32.dll have symbols which also appear in winmm.dll. However, on older versions of 32-bit Windows, those symbols are not found in kernel32.dll, and will thus, fail.