### PR TITLE
Build the wall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
 
 script:
   - mkdir -p build; cd build;
-  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$TRAVIS_OS_NAME-x64" -DCMAKE_BUILD_TYPE:STRING="Debug" ../
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$TRAVIS_OS_NAME-x64" -DCMAKE_BUILD_TYPE:STRING="Debug" -DCMAKE_CXX_FLAGS_DEBUG="-Wall -Wpedantic" ../
   - make VERBOSE=1
   - if [ $TRAVIS_OS_NAME = linux ]; then make doc; fi
   - make install

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -66,7 +66,6 @@ int main()
 		sleep(1);
 	}
 
-	int id = 1;
 	cout << "before device loop" << endl;
 	for (int i = 0; i < deviceManager.getAvailableDeviceTypes().size(); ++i)
 	{


### PR DESCRIPTION
This corrects the only remaining warning in GCC (an unused variable in the test program code), and updates the Travis command line with `-DCMAKE_CXX_FLAGS_DEBUG="-Wall -Wpedantic"` to enable warnings if anything is amiss in the code.

(`-Wextra`, the other common set of GCC warnings, unfortunately produces a lot of false positives in the JUCE code, so it's omitted for now.)