### PR TITLE
Travis: Add Ubuntu Bionic (18.04) builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ matrix:
   include:
     - os: linux
       dist: xenial
+      name: "Ubuntu 16.04 Xenial"
+    - os: linux
+      dist: bionic
+      name: "Ubuntu 18.04 Bionic"
     - os: osx
+      name: "Apple macOS"
 
 addons:
   apt:


### PR DESCRIPTION
This adds a third build environment, Ubuntu 18.04, alongside the existing 16.04 and macOS builds. (IMHO we can probably drop 16.04 once we've got this shaken out, but for now they'll be run side-by-side.)