### PR TITLE
ZLIB: Use IMPORTED target for linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 if(UNIX AND APPLE)
 	SET(JUCE_PLATFORM_SPECIFIC_DIR build/macosx/platform_specific_code)
-	SET(JUCE_PLATFORM_SPECIFIC_LIBRARIES "-framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreAudio -framework CoreMidi -framework IOKit -framework AGL -framework AudioToolbox -framework QuartzCore -lobjc -lz -framework Accelerate")
+	SET(JUCE_PLATFORM_SPECIFIC_LIBRARIES "-framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreAudio -framework CoreMidi -framework IOKit -framework AGL -framework AudioToolbox -framework QuartzCore -lobjc -framework Accelerate")
 	SET(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -flax-vector-conversions")
 endif()
 
@@ -190,10 +190,9 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 target_link_libraries(openshot-audio PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
-# ZLIB
+# ZLIB -- uses IMPORTED target ZLIB::ZLIB which has existed since CMake 3.1
 find_package(ZLIB REQUIRED)
-include_directories(${ZLIB_INCLUDE_DIR})
-target_link_libraries(openshot-audio PUBLIC ${ZLIB_LIBRARIES})
+target_link_libraries(openshot-audio PUBLIC ZLIB::ZLIB)
 
 target_link_libraries(openshot-audio PUBLIC
 		${CMAKE_DL_LIBS}


### PR DESCRIPTION
Since CMake 3.1 (our minimum supported version), `FindZLIB.cmake` creates the `IMPORTED` target `ZLIB::ZLIB` to encapsulate its dependencies. Use that to properly link the library and include dirs on all three platforms.