### PR TITLE
ALSA: Use or create IMPORTED library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,20 +137,12 @@ if(UNIX AND APPLE)
 	SET(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -flax-vector-conversions")
 endif()
 
-if(UNIX AND NOT APPLE) #Linux
-	find_package(ALSA REQUIRED)
-	include_directories(${ALSA_INCLUDE_DIR})
-	ADD_DEFINITIONS(-DLINUX)
-	SET(JUCE_PLATFORM_SPECIFIC_LIBRARIES ${ALSA_LIBRARIES})
-endif()
-
 # Default extension for source files
 if(UNIX AND APPLE)
-	SET(SOURCE_EXTENSION "mm")
+  SET(SOURCE_EXTENSION "mm")
 else ()
-    SET(SOURCE_EXTENSION "cpp")
+  SET(SOURCE_EXTENSION "cpp")
 endif()
-
 
 # List of modules to build
 set(JUCE_MODULES
@@ -166,7 +158,7 @@ foreach(j_module IN LISTS JUCE_MODULES)
 		JuceLibraryCode/include_juce_${j_module}.${SOURCE_EXTENSION} )
 endforeach()
 
-ADD_LIBRARY(openshot-audio SHARED ${JUCE_SOURCES} )
+add_library(openshot-audio SHARED ${JUCE_SOURCES} )
 
 # Include header directories
 target_include_directories(openshot-audio PUBLIC
@@ -189,6 +181,20 @@ set_target_properties(openshot-audio
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 target_link_libraries(openshot-audio PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
+
+# ALSA (Linux only)
+if(UNIX AND NOT APPLE)
+  find_package(ALSA REQUIRED)
+  if (ALSA_FOUND AND NOT TARGET ALSA::ALSA) # CMake < 3.12
+    add_library(ALSA::ALSA INTERFACE IMPORTED)
+    set_target_properties(ALSA::ALSA PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${ALSA_INCLUDE_DIR}
+      INTERFACE_LINK_LIBRARIES ${ALSA_LIBRARIES})
+  endif()
+  target_compile_definitions(openshot-audio PUBLIC LINUX)
+  target_link_libraries(openshot-audio PUBLIC ALSA::ALSA)
+endif()
 
 # ZLIB
 find_package(ZLIB REQUIRED)
@@ -246,14 +252,14 @@ if(PYTHONINTERP_FOUND)
 	if(TARGET doxygen)
 		add_dependencies(doxygen process-source-files)
 	endif()
-	
+
 	# Install docs, if the user builds them with `make doc`
 	install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
 	install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Python3 and Doxygen)\")")
-	
+
 	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
 		DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
 		MESSAGE_NEVER # Don't spew about file copies
 		OPTIONAL )    # No error if the docs aren't found
-		
+
 endif()


### PR DESCRIPTION
As with the previous PR, this links libopenshot-audio with the `IMPORTED` target `ALSA::ALSA`, rather than the associated variables.

However, since CMake prior to 3.12 didn't create the `ALSA::ALSA` target, for backwards compatibility we create it ourselves. Tested with both CMake 3.1 and 3.14.