### PR TITLE
Travis: Remove unused packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ addons:
   apt:
     packages:
       - cmake
-      - swig
       - libasound2-dev
-      - libunittest++-dev
       - doxygen
       - graphviz
 
@@ -25,8 +23,6 @@ addons:
     update: true
     packages:
       - gcc
-      - unittest-cpp
-      - swig
 
 script:
   - mkdir -p build; cd build;


### PR DESCRIPTION
The `.travis.yml` file is installing SWIG and UnitTest++ on both Linux and MacOS, which makes no sense because neither is needed to build libopenshot-audio.