### PR TITLE
Apply JUCE input device fix

### DIFF
--- a/JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
+++ b/JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
@@ -336,10 +336,10 @@ void AudioDeviceManager::insertDefaultDeviceNames (AudioDeviceSetup& setup) cons
 {
     if (auto* type = getCurrentDeviceTypeObject())
     {
-        if (setup.outputDeviceName.isEmpty())
+        if (numOutputChansNeeded > 0 && setup.outputDeviceName.isEmpty())
             setup.outputDeviceName = type->getDeviceNames (false) [type->getDefaultDeviceIndex (false)];
 
-        if (setup.inputDeviceName.isEmpty())
+        if (numInputChansNeeded > 0 && setup.inputDeviceName.isEmpty())
             setup.inputDeviceName = type->getDeviceNames (true) [type->getDefaultDeviceIndex (true)];
     }
 }


### PR DESCRIPTION
This is a cherry-pick of [this commit](https://github.com/WeAreROLI/JUCE/commit/8a66f1f3d3750b9ecdf909821dd4b144511b00a2) from the JUCE source  tree, which is reported to fix the input-device mismatch issue OpenShot users have been reporting. This is meant as a stopgap measure until the JUCE 5.4.5 upgrade can be merged (#77).

Fixes OpenShot/openshot-qt#3073, fixes OpenShot/openshot-qt#2957