### PR TITLE
Some fixes to Main.cpp: line endings, std:: prefixes, use juce::Thread::sleep()

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -31,42 +31,36 @@
  */
 
 #include <iostream>
-#include <unistd.h>
 #include "../JuceLibraryCode/JuceHeader.h"
-
-#if JUCE_MINGW
-#define sleep(a) Sleep(a * 1000)
-#include <windows.h>
-#endif
-
-using namespace std;
 
 //==============================================================================
 int main()
 {
 
 	// Initialize audio devices
-	cout << "Begin init" << endl;
+	std::cout << "Begin init" << std::endl;
 	AudioDeviceManager deviceManager;
-	String error = deviceManager.initialise (	0, /* number of input channels */
-								2, /* number of output channels */
-								0, /* no XML settings.. */
-								true  /* select default device on failure */);
+	String error = deviceManager.initialise (
+		0, /* number of input channels */
+		2, /* number of output channels */
+		0, /* no XML settings.. */
+		true  /* select default device on failure */
+	);
 
 	// Output error (if any)
 	if (error.isNotEmpty()) {
-		cout << "Error on initialise(): " << error.toStdString() << endl;
+		std::cout << "Error on initialise(): " << error.toStdString() << std::endl;
 	}
 
 	// Play test sound
-	cout << "Playing sound now" << endl;
+	std::cout << "Playing sound now" << std::endl;
 	deviceManager.playTestSound();
 	for (int x = 1; x <= 5; x++) {
-		cout << "... " << x << endl;
-		sleep(1);
+		std::cout << "... " << x << std::endl;
+		juce::Thread::sleep(1000);
 	}
 
-	cout << "before device loop" << endl;
+	std::cout << "before device loop" << std::endl;
 	for (int i = 0; i < deviceManager.getAvailableDeviceTypes().size(); ++i)
 	{
 		const AudioIODeviceType* t = deviceManager.getAvailableDeviceTypes()[i];
@@ -78,10 +72,10 @@ int main()
 			String menuName;
 
 			menuName << deviceName << " (" << t->getTypeName() << ")";
-			cout << menuName << endl;
+			std::cout << menuName << std::endl;
 		}
 	}
-	cout << "after device loop" << endl;
+	std::cout << "after device loop" << std::endl;
 
 	// Stop audio devices
 	deviceManager.closeAudioDevice();


### PR DESCRIPTION
This PR makes some changes to the `src/Main.cpp` file:
- Convert from Windows CRLF line-endings to Unix CR, and clean up some tab-spacing
- Eliminate `using namespace std;` by adding `std::` prefixes
- Eliminate the hackery of platform-specific `sleep()` implementations by using `juce::Thread::sleep()`, which is supported cross-platform