### PR TITLE
Travis: Remove homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: xenial
@@ -18,11 +18,6 @@ addons:
       - libasound2-dev
       - doxygen
       - graphviz
-
-  homebrew:
-    update: true
-    packages:
-      - gcc
 
 script:
   - mkdir -p build; cd build;


### PR DESCRIPTION
Most of our build time is taken up by the MacOS build, and most of _that_ time is spent updating Homebrew packages we don't actually need or use.

So, this is an experiment with using a config that includes `homebrew: update: false`. I _think_ I tried that originally, and it caused some sort of problems with the installs not working... but I can't remember for sure, and if it's possible to save all that time per build, it's worth attempting.