### PR TITLE
CMake: Add hex-version helper source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 ################ PROJECT VERSION ####################
 set(PROJECT_VERSION_FULL "0.2.0-dev1")
 set(PROJECT_SO_VERSION 7)
-set(HEX_VERSION_OVERRIDE "0x200") # For CMake < 3.13
 
 # Remove the dash and anything following, to get the #.#.# version for project()
 STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")
@@ -57,13 +56,31 @@ STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")
 PROJECT(libopenshot-audio LANGUAGES C CXX VERSION ${VERSION_NUM})
 
 # JuceHeader.h needs a hexadecimal version number for the project
-if(CMAKE_VERSION VERSION_LESS 3.13)
-	set(PROJECT_VERSION_HEX ${HEX_VERSION_OVERRIDE}) # Ugly hardcoding
+if(CMAKE_VERSION VERSION_GREATER 3.13)
+  math(EXPR PROJECT_VERSION_HEX
+    "(${PROJECT_VERSION_MAJOR} << 16) + \
+     (${PROJECT_VERSION_MINOR} << 8) + \
+     (${PROJECT_VERSION_PATCH})" OUTPUT_FORMAT HEXADECIMAL )
 else()
-	math(EXPR PROJECT_VERSION_HEX
-		"(${PROJECT_VERSION_MAJOR} << 16) + \
-		(${PROJECT_VERSION_MINOR} << 8) + \
-		(${PROJECT_VERSION_PATCH})" OUTPUT_FORMAT HEXADECIMAL )
+  # Compile and run a C++ program to generate the hex version
+  set(HEX_COMPILE_DEFINITIONS
+    -DVERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+    -DVERSION_MINOR=${PROJECT_VERSION_MINOR}
+    -DVERSION_PATCH=${PROJECT_VERSION_PATCH}
+  )
+  try_run(HEX_VERSION_RUN HEX_VERSION_BUILD
+    ${CMAKE_CURRENT_BINARY_DIR}/hex_version
+    ${PROJECT_SOURCE_DIR}/src/hex_version.cpp
+    COMPILE_DEFINITIONS ${HEX_COMPILE_DEFINITIONS}
+    RUN_OUTPUT_VARIABLE HEX_VERSION_OUTPUT
+  )
+  if (NOT HEX_VERSION_BUILD)
+    message(ERROR "Failed to compile hex-version utility!")
+  elseif(HEX_VERSION_RUN STREQUAL FAILED_TO_RUN)
+    message(ERROR "Could not execute hex-version utility!")
+  else()
+    set(PROJECT_VERSION_HEX ${HEX_VERSION_OUTPUT})
+  endif()
 endif()
 
 message("\

--- a/src/hex_version.cpp
+++ b/src/hex_version.cpp
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * @brief Build utility program to generate hex-format version numbers
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2008-2020 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of OpenShot Audio
+ * Library (libopenshot-audio), an open-source project dedicated to delivering
+ * high quality audio editing and playback solutions to the world. For more
+ * information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Audio Library (libopenshot-audio) is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General
+ * Public License as published by the Free Software Foundation, either version
+ * 3 of the License, or (at your option) any later version.
+ *
+ * OpenShot Audio Library (libopenshot-audio) is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @mainpage OpenShot Audio Library C++ API
+ *
+ * Welcome to the OpenShot Audio Library C++ API.  This library is used by libopenshot to enable audio
+ * features, which powers the <a href="http://www.openshot.org">OpenShot Video Editor</a> application.
+ */
+
+ #include <iostream>
+ #include <ios>
+
+// The following values must be defined at compile time:
+// VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH
+
+#if !defined(VERSION_MAJOR) || !defined(VERSION_MINOR) || !defined(VERSION_PATCH)
+    #pragma error "Define version components on compiler command line!"
+#endif
+
+int main()
+{
+    
+    int hex_version = (VERSION_MAJOR << 16) +
+                      (VERSION_MINOR << 8) +
+                      (VERSION_PATCH);
+                      
+    std::cout << std::hex << "0x" << hex_version;
+}


### PR DESCRIPTION
Use a C++ program (built and run by CMake when generating the build) to convert the dotted-decimal project version into a hexadecimal number instead of hardcoding it, for CMake < 3.13.