### PR TITLE
Travis: Add macOS build w/ newer XCode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ jobs:
       name: "Ubuntu 18.04 Bionic"
     - os: osx
       name: "Apple macOS"
+    - os: osx
+      osx_image: xcode11.3
+      name: "Apple macOS (XCode 11.3)"
 
 addons:
   apt:


### PR DESCRIPTION
It looks like some of the APIs being used in our current JUCE code are deprecated, as XCode calls out when building with a recent version. Add such a build to Travis, so we can keep an eye on that.