### PR TITLE
Add shell script to output version

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+grep 'set.*(.*PROJECT_VERSION_FULL' CMakeLists.txt\
+ |sed -e 's#set(PROJECT_VERSION_FULL.*"\(.*\)\")#\1#;q'
+


### PR DESCRIPTION
This adds a `version.sh` script that uses grep and sed to extract the `PROJECT_FULL_VERSION` string from the `CMakeLists.txt` file. (Hopefully we'll all remember to update it if we change the format at any point.)

This is useful for building libopenshot-audio as a Mac Homebrew `brew diy` project, which allows ad-hoc building of packages that install directly into the Homebrew environment.

e.g.
```sh
$ cd libopenshot-audio
$ cmake $(brew diy --name libopenshot-audio --version $(sh ./version.sh)) .
[CMake runs with CMAKE_INSTALL_PREFIX set to $(brew --cellar)/libopenshot-audio/<version>/]
$ cmake --build .
$ cmake --build . --target install
$ brew link libopenshot-audio
```
...and libopenshot-audio is linked into `/usr/local/opt/{lib,include}`.
