### PR TITLE
Add JUCE_MODULES_PATH config variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.2.0-dev2")
+set(PROJECT_VERSION_FULL "0.2.0-dev3")
 set(PROJECT_SO_VERSION 7)
 
 # Remove the dash and anything following, to get the #.#.# version for project()
@@ -93,6 +93,14 @@ message("SO/API/ABI Version: ${PROJECT_SO_VERSION}" )
 # XXX: This must be AFTER THE PROJECT() COMMAND w/ languages enabled,
 #      in order to properly configure CMAKE_INSTALL_LIBDIR path
 include(GNUInstallDirs)
+
+### Build configuration (options)
+
+# Specify alternative location for JUCE modules (debian has their own)
+set(JUCE_MODULES_PATH "${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules" CACHE PATH
+    "Location of the JUCE source code 'modules' directory")
+
+message(STATUS "Using JUCE module path: ${JUCE_MODULES_PATH}")
 
 ########## Configure headers ##############
 configure_file(include/JuceHeader.h.in include/JuceHeader.h @ONLY)
@@ -163,16 +171,16 @@ endif()
 
 # List of modules to build
 set(JUCE_MODULES
-	audio_basics
-	audio_devices
-	audio_formats
-	core
-	data_structures
-	events )
+	juce_audio_basics
+	juce_audio_devices
+	juce_audio_formats
+	juce_core
+	juce_data_structures
+	juce_events )
 # Convert to list of source files (extension based on OS)
 foreach(j_module IN LISTS JUCE_MODULES)
 	list(APPEND JUCE_SOURCES
-		JuceLibraryCode/include_juce_${j_module}.${SOURCE_EXTENSION} )
+		JuceLibraryCode/include_${j_module}.${SOURCE_EXTENSION} )
 endforeach()
 
 add_library(openshot-audio SHARED ${JUCE_SOURCES} )
@@ -180,7 +188,7 @@ add_library(openshot-audio SHARED ${JUCE_SOURCES} )
 # Include header directories
 target_include_directories(openshot-audio PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules>
+	$<BUILD_INTERFACE:${JUCE_MODULES_PATH}>
 	$<INSTALL_INTERFACE:include/libopenshot-audio> )
 
 # Set SONAME and other library properties
@@ -228,9 +236,11 @@ add_subdirectory(src)
 #################### INSTALLATION #####################
 
 # Install Header Files
-INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules/
-	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot-audio
-	FILES_MATCHING PATTERN "*.h" )
+foreach(j_module IN LISTS JUCE_MODULES)
+  install(DIRECTORY ${JUCE_MODULES_PATH}/${j_module}/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot-audio/${j_module}
+    FILES_MATCHING PATTERN "*.h" )
+endforeach()
 
 # Install library
 INSTALL(TARGETS openshot-audio
@@ -249,7 +259,7 @@ find_package(PythonInterp 3)
 if(PYTHONINTERP_FOUND)
     # Pre-process the sources to fix documentation formatting
     add_custom_target(process-source-files
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doc/process_source_files.py ${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules "docs"
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doc/process_source_files.py ${JUCE_MODULES_PATH} "docs"
         COMMENT "Formatting source code for documentation"
         VERBATIM )
 

--- a/JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h
@@ -446,8 +446,7 @@ inline bool juce_isfinite (float value) noexcept
    #if JUCE_WINDOWS && ! JUCE_MINGW
     return _finite (value) != 0;
    #else
-    using std::isfinite;
-    return isfinite (value);
+    return std::isfinite (value);
    #endif
 }
 
@@ -457,8 +456,7 @@ inline bool juce_isfinite (double value) noexcept
    #if JUCE_WINDOWS && ! JUCE_MINGW
     return _finite (value) != 0;
    #else
-    using std::isfinite;
-    return isfinite (value);
+    return std::isfinite (value);
    #endif
 }
 


### PR DESCRIPTION
(See [Debian bug 925755](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925755) for background.)

Debian have a distro package `juce-modules-source` that they can build against, but they need to be able to point us there. This PR adds a `JUCE_MODULES_PATH` cache variable, default to `${CMAKE_CURRENT_BINARY_DIR}/JuceLibraryCode/modules`, that can be overridden at build system generation time via:
```sh
cmake -DJUCE_MODULES_PATH=/usr/share/juce/modules
```

Tha'll allow Debian to build against their version of JUCE, instead of our bundled one.

I also reverted the old `isfinite()` fix patch, so that we're using an _unpatched_ version of JUCE, since they'll be doing the same. I figured out how to fix the `isfinite()` thing from the libopenshot build configs end, and a corresponding PR there will ensure that this still works.

Bumped the libopenshot-audio version to `0.2.0-dev3` because of the build system changes.