### PR TITLE
CMake: Add support for local UserDefaults.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 .settings
 .idea/*
+cmake/UserDefaults.cmake
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,27 @@ For more information, please visit <http://www.openshot.org/>.
 ################ ADD CMAKE MODULES ##################
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
+### Note: A file cmake/UserDefaults.cmake in the project repository
+### will by default be read to pre-set options for each build. The
+### contents are processed before the initial project() command.
+###
+### It is safe to use this file to store your local build settings.
+### It is listed in the project .gitignore and cannot be committed.
+###
+### To temporarily override the automatic loading of UserDefaults.cmake
+### in the current build, set IGNORE_DEFAULTS on the cmake command line:
+###
+###   cmake -DIGNORE_DEFAULTS:BOOL=TRUE -B build -S .
+
+### Load user/project defaults if supported, unless overridden
+option(IGNORE_DEFAULTS OFF "Don't import local settings from UserDefaults.cmake (CMake 3.15+ only)")
+if (CMAKE_VERSION VERSION_GREATER 3.15 AND NOT IGNORE_DEFAULTS)
+  set(_defaults_file "${CMAKE_SOURCE_DIR}/cmake/UserDefaults.cmake")
+  if (EXISTS ${_defaults_file})
+    set(CMAKE_PROJECT_INCLUDE_BEFORE "${_defaults_file}")
+  endif()
+endif()
+
 ################ PROJECT VERSION ####################
 set(PROJECT_VERSION_FULL "0.2.0-dev3")
 set(PROJECT_SO_VERSION 7)


### PR DESCRIPTION
I find myself setting the same options over and over again every time I build the library — assuming I remember, of course.

There's my `CMAKE_INSTALL_PREFIX`, my preferred `CMAKE_BUILD_TYPE`, etc. They're options that can't be incorporated into the project defaults because they're inherently _local_, but they're still things I'd rather not have to deal with every single time.

This PR adds configuration to take advantage of a CMake feature (only present in CMake 3.15+, I'm afraid) that will inject a source file into the beginning of the build, right before the `project()` command that kicks off the build environment generation. That file can be used to set up local defaults for the build which will be used each time, so they don't have to be passed on the command line.

If there is a file in the repository named `cmake/UserDefaults.cmake`, if the build is running under CMake 3.15, and if the option `IGNORE_DEFAULTS` has **not** been set on the command line, then CMake will source the `cmake/UserDefaults.cmake` file prior to running its own build scripts. Any settings made in that file will influence the subsequent build.

Setting things properly can be a bit tricky. Some things, like find module parameters, only need to be set as CMake variables:
```cmake
set(Package_ROOT /path/to/package/dir)
```

Other settings require more work to properly configure. In order to be effective both during and after the generation process, something like `CMAKE_INSTALL_PREFIX` has to be set as a cache variable, which requires the full signature:
```cmake
set(CMAKE_INSTALL_PREFIX "install-x64" CACHE PATH "Doc string")
```
But, with a little persistence it's possible to avoid the burden of specifying so much on the command line each time. 

The `cmake/UserDefaults.cmake` project is added to the checked-in `.gitignore` file, so there's no danger of anyone accidentally committing their local settings.

If anyone thinks this could be made better or more useful, I'm open to suggestions — including on the name. I thought about possibly calling it `cmake/LocalDefaults.cmake`, since that's perhaps closer to what it represents., but I went with "User" instead because I wanted to emphasize that the file is a place to store _personal_ build options and preferences, things that simply aren't appropriate to manage directly in the project's shared configuration.

(i'll naturally be opening a PR for libopenshot that adds the same functionality there.)