### PR TITLE
Travis: Add Focal build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ language: cpp
 jobs:
   include:
     - os: linux
-      dist: xenial
-      name: "Ubuntu 16.04 Xenial"
+      dist: focal
+      name: "Ubuntu 20.04 Focal"
+    - os: osx
+      osx_image: xcode11.3
+      name: "Apple macOS (XCode 11.3)"
     - os: linux
       dist: bionic
       name: "Ubuntu 18.04 Bionic"
     - os: osx
       name: "Apple macOS"
-    - os: osx
-      osx_image: xcode11.3
-      name: "Apple macOS (XCode 11.3)"
+    - os: linux
+      dist: xenial
+      name: "Ubuntu 16.04 Xenial"
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 
 message("
 Generating build files for OpenShot with CMake ${CMAKE_VERSION}
-  Building ${PROJECT_NAME} (version ${PROJECT_VERSION_FULL} (${PROJECT_VERSION_HEX})
+  Building ${PROJECT_NAME} version ${PROJECT_VERSION_FULL} (${PROJECT_VERSION_HEX})
   SO/API/ABI Version: ${PROJECT_SO_VERSION}
 ")
 


### PR DESCRIPTION
This PR adds a fifth CI build, using Ubuntu's latest LTS release.

I'm tempted to drop Xenial _off_ the list (four builds seems like plenty), but maybe instead I'll switch one of the Ubuntu builds over to Clang or something like that. Might as well make themselves useful.