### PR TITLE
.gitlab-ci.yml: Capture build commit epoch time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,11 +12,12 @@ linux-builder:
     paths:
     - build/install-x64/*
   script:
+    - export COMMIT_DATE_UNIX=$(git log --date=unix --format="%cd" $CI_COMMIT_SHA)
     - mkdir -p build; cd build;
     - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - make
     - make install
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "install-x64/share/$CI_PROJECT_NAME"
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCOMMIT_DATE_UNIX:$COMMIT_DATE_UNIX" > "install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 '@^')..@ --oneline --no-abbrev --date=short --no-merges --pretty="tformat:$GIT_LOG_FORMAT" > "install-x64/share/$CI_PROJECT_NAME.log"
   when: always
   except:
@@ -31,11 +32,12 @@ mac-builder:
     paths:
     - build/install-x64/*
   script:
+    - export COMMIT_DATE_UNIX=$(git log --date=unix --format="%cd" -1 $CI_COMMIT_SHA)
     - mkdir -p build
     - cmake -B build -S . -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=build/install-x64" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk" -D"CMAKE_OSX_DEPLOYMENT_TARGET=10.9"
     - cmake --build build
     - cmake --install build
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCOMMIT_DATE_UNIX:$COMMIT_DATE_UNIX" > "build/install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 '@^')..@ --oneline --no-abbrev --date=short --no-merges --pretty="tformat:$GIT_LOG_FORMAT" > "build/install-x64/share/$CI_PROJECT_NAME.log"
   when: always
   except:
@@ -50,6 +52,7 @@ windows-builder-x64:
     paths:
     - build\install-x64\*
   script:
+    - $env:COMMIT_DATE_UNIX = git log --date=unix --format="%cd" -1 $CI_COMMIT_SHA
     - $env:LIBOPENSHOT_AUDIO_DIR = "C:\msys64\usr"
     - $env:UNITTEST_DIR = "C:\msys64\usr"
     - $env:ZMQDIR = "C:\msys64\usr"
@@ -58,7 +61,7 @@ windows-builder-x64:
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=build/install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release"
     - cmake --build build
     - cmake --install build
-    - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
+    - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCOMMIT_DATE_UNIX:$env:COMMIT_DATE_UNIX" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --no-abbrev --date=short --no-merges --pretty="tformat:$GIT_LOG_FORMAT" > "build/install-x64/share/$CI_PROJECT_NAME.log"
   when: always
@@ -74,6 +77,7 @@ windows-builder-x86:
     paths:
     - build\install-x86\*
   script:
+    - $env:COMMIT_DATE_UNIX = git log --date=unix --format="%cd" -1 $CI_COMMIT_SHA
     - $env:LIBOPENSHOT_AUDIO_DIR = "C:\msys32\usr"
     - $env:UNITTEST_DIR = "C:\msys32\usr"
     - $env:ZMQDIR = "C:\msys32\usr"
@@ -82,7 +86,7 @@ windows-builder-x86:
     - cmake -B build -s . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=build/install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_C_FLAGS=-m32"
     - cmake --build build
     - cmake --install build
-    - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
+    - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCOMMIT_DATE_UNIX:$env:COMMIT_DATE_UNIX" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --no-abbrev --date=short --no-merges --pretty="tformat:$GIT_LOG_FORMAT" > "build/install-x86/share/$CI_PROJECT_NAME.log"
   when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ linux-builder:
     paths:
     - build/install-x64/*
   script:
-    - export COMMIT_DATE_UNIX=$(git log --date=unix --format="%cd" $CI_COMMIT_SHA)
+    - export COMMIT_DATE_UNIX=$(git log --date=unix --format="%cd" -1 $CI_COMMIT_SHA)
     - mkdir -p build; cd build;
     - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - make


### PR DESCRIPTION
This PR, along with OpenShot/libopenshot#588 and OpenShot/openshot-qt#3828, implements an idea I had while discussing Daily Build versions with @rexdk in OpenShot/openshot-qt#3825:

By using the UNIX epoch date of the _openshot-qt **commit**_ that the build is generated from, instead of the value of `time.time()`, we can ensure that the set of Daily Build files generated for a given build run all have the _same_ version identifiers in their filename, and differ only by the specifics of the format/architecture targeted.

Before, due to the use of `int(time.time())` to set the first part of the build identifier, each of the builders' files was named slightly differently. 

Now, instead of e.g. (from the most recent Daily Build run):
```
OpenShot-v2.5.1-dev2-1604704263-b910d2f6-2cb4eeff-x86_64.AppImage
OpenShot-v2.5.1-dev2-1604704263-b910d2f6-2cb4eeff-x86_64.AppImage.torrent
OpenShot-v2.5.1-dev2-1604704807-b910d2f6-2cb4eeff-x86.exe
OpenShot-v2.5.1-dev2-1604704813-b910d2f6-2cb4eeff-x86_64.exe
OpenShot-v2.5.1-dev2-1604704807-b910d2f6-2cb4eeff-x86.exe.torrent
OpenShot-v2.5.1-dev2-1604704813-b910d2f6-2cb4eeff-x86_64.exe.torrent
OpenShot-v2.5.1-dev2-1604707336-b910d2f6-2cb4eeff-x86_64.dmg
OpenShot-v2.5.1-dev2-1604707336-b910d2f6-2cb4eeff-x86_64.dmg.torrent
```
We'd instead have (based on the timestamp of the triggering commit):
```
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.AppImage
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.AppImage.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86.exe
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.exe
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86.exe.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.exe.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.dmg
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.dmg.torrent
```
Much nicer, IMHO.

This PR adds capture of the libopenshot-audio commit timestamp (as a UNIX epoch time), and storage in the `share/libopenshot-audio` metadata file. While it isn't strictly _necessary_ to make this change, and the data collected for `libopenshot-audio` doesn't actually get used, the change does require that we capture this data for `openshot-qt` and I felt it best if all three projects' metadata files keep the same format. (Especially as it's parsed by `build-server.py`.)