### PR TITLE
CI: Pare down Windows deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
       with:
         update: true
         install: >-
-          mingw-w64-x86_64-toolchain
-          base-devel
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-pkgconf
+          mingw-w64-x86_64-make
+          make
+          pkgconf
 
     - uses: haya14busa/action-cond@v1
       id: generator


### PR DESCRIPTION
`setup-msys2` in the CI workflow is installing all of `mingw-w64-x86_64-toolchain` and `base-devel` which is **way** too many packages we don't need or use. Trying to pare it down to just the minimum required to build libopenshot-audio.