### PR TITLE
CMake: Don't export openshot-audio-demo

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ if(CMAKE_VERSION VERSION_LESS 3.8)
 endif()
 
 install(TARGETS openshot-audio-demo
-  EXPORT OpenShotAudioTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 


### PR DESCRIPTION
The Ubuntu PPA packaging doesn't include the `openshot-audio-demo` binary, because why would it?

But, turns out if it's _not_ installed, then having it in the target file causes CMake to abort with a missing-file error. So, better not to include it in the EXPORTED configuration at all.