### PR TITLE
GH Actions: Build and publish docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install cmake doxygen graphviz python3
+          sudo apt install cmake libasound2-dev doxygen graphviz python3
 
       - name: Build libopenshot-audio docs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: libopenshot-audio documentation
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install cmake doxygen graphviz python3
+
+      - name: Build libopenshot-audio docs
+        run: |
+          mkdir build
+          pushd build
+          cmake -B . -S ..
+          cmake --build . --target doc
+          popd
+
+      # Create an artifact out of the generated HTML
+      - uses: actions/upload-artifact@v2.2.2
+        with:
+          name: "OpenShotAudio-docs"
+          path: "build/doc/html/"


### PR DESCRIPTION
Just like we've been doing in OpenShot/openshot-qt for a while now, this adds a Github Actions workflow to generate the repo's documentation, then publish it as a downloadable build artifact.