### PR TITLE
Fix legacy JuceHeader.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,17 +115,7 @@ add_feature_info("JUCE path" TRUE "Using JUCE sources from: ${_juce_dir}")
 
 # Generate our custom headers from templates
 configure_file(include/OpenShotAudio.h.in include/OpenShotAudio.h @ONLY)
-if(UNIX AND CMAKE_VERSION VERSION_GREATER 3.14)
-  # Symlink to the old header name, for backwards compatibility
-  file(CREATE_LINK
-    OpenShotAudio.h
-    "${CMAKE_CURRENT_BINARY_DIR}/include/JuceHeader.h"
-    SYMBOLIC
-  )
-else()
-  # We can't symlink it, so just make a copy
-  configure_file(include/OpenShotAudio.h.in include/JuceHeader.h @ONLY)
-endif()
+configure_file(include/JuceHeader.h.in include/JuceHeader.h @ONLY)
 configure_file(include/AppConfig.h.in include/AppConfig.h @ONLY)
 list(APPEND _extra_headers
   ${CMAKE_CURRENT_BINARY_DIR}/include/OpenShotAudio.h

--- a/include/JuceHeader.h.in
+++ b/include/JuceHeader.h.in
@@ -1,0 +1,12 @@
+/*
+    Legacy include file, provided for backwards-compatibility purposes
+    only. You should update your code to include <OpenShotAudio.h>
+    instead of this file.
+
+    (This comment may become a build-time warning message at some
+    future date.)
+*/
+
+#pragma once
+#include "./OpenShotAudio.h"
+


### PR DESCRIPTION
My recent #118 changed the name of the primary header from `JuceHeader.h` to `OpenShotAudio.h`, but also installed that file as a link/copy under the name `JuceHeader.h` for backwards compatibility.

Turns out, that's a problem if you happen to mix both `#include` forms in the same project, because you'll end up with errors about symbols being redefined or duplicated. So, this PR replaces the copy/link to `JuceHeader.h` with a new stub file that contains only two business lines:
```c++
#pragma once
#include "./OpenShotAudio.h"
```
That way, nothing breaks if both files are `#included` together.
