### PR TITLE
CMake: Correct EXPORTED config install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,9 +315,7 @@ export(EXPORT OpenShotAudioTargets
 # Package the exported targets for external consumers
 include(CMakePackageConfigHelpers)
 
-# (Borrowed from cppzmq/CMakeList.txt)
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}"
+set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   CACHE STRING "install path for CMake configuration")
 
 # Install EXPORTED configuration


### PR DESCRIPTION
I was steered wrong, and set up the `OpenShotAudioConfig.cmake` file (and friends) to install to `share/cmake/`... that path is OK for arch-independent installs, but _not_ for architecture-bound library installs like `libopenshot-audio`. Those should go into the same `${CMAKE_INSTALL_LIBDIR}` that the libraries themselves go into, so that a multi-arch system can simultaneously have, e.g.:
* `/usr/lib/cmake/OpenShotAudio/OpenShotAudioConfig.cmake` pointing to a 32-bit version
* `/usr/lib64/xmake/OpenShotAudio/OpenShotAudioConfig.cmake` pointing to a 64-bit version

...and the right one will be used automatically.

Looking to merge this as soon as the CI is ready, because it has to be coordinated with a corresponding change to the Ubuntu PPA packaging control files (as they expect files to be installed into this path, by name).