### PR TITLE
Ensure NEED_ASIO is always set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ endif()
 # (Ruby) have issues dealing with JUCE's use of isFinite()
 target_compile_definitions(openshot-audio INTERFACE HAVE_ISFINITE=1)
 
+# For EXPORTED config
+set(NEED_ASIO FALSE)
 if(WIN32)
   # Try to load ASIO SDK
   find_package(ASIO)


### PR DESCRIPTION
Because `@NEED_ASIO@` is substituted in generating the CMake `Config.cmake` file, it should always have a value of either `TRUE` or `FALSE`. This PR ensures that it defaults to `FALSE`.
