### PR TITLE
Demo app: Fix Windows device detection

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -40,8 +40,38 @@
 #endif
 #include "OpenShotAudio.h"
 
+// Subclass the AudioDeviceManager so we can skip WASAPI devices on Windows
+class TestAudioDeviceManager : public juce::AudioDeviceManager {
+public:
+    static void addIfNotNull (
+        juce::OwnedArray<juce::AudioIODeviceType>& list,
+        juce::AudioIODeviceType* const device)
+    {
+        if (device != nullptr)
+            list.add (device);
+    }
 
-void display_device_probe(juce::AudioDeviceManager& deviceManager) {
+    void createAudioDeviceTypes (juce::OwnedArray<juce::AudioIODeviceType>& list) override
+    {
+        /*
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (false));
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_WASAPI (true));
+        */
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_DirectSound());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_ASIO());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_CoreAudio());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_iOSAudio());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_Bela());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_ALSA());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_JACK());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_Oboe());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_OpenSLES());
+        addIfNotNull (list, juce::AudioIODeviceType::createAudioIODeviceType_Android());
+    }
+};
+
+
+void display_device_probe(TestAudioDeviceManager& deviceManager) {
     std::cout << "Audio device probe results:\n";
     int device_count = 0;
     for (const auto& t : deviceManager.getAvailableDeviceTypes()) {
@@ -56,20 +86,22 @@ void display_device_probe(juce::AudioDeviceManager& deviceManager) {
     }
     std::cout << "Discovered " << device_count << " total audio devices.\n\n";
 
-    std::cout << "Current audio device type: "
-              << (deviceManager.getCurrentDeviceTypeObject() != nullptr
-                  ? deviceManager.getCurrentDeviceTypeObject()->getTypeName()
-                  : "<none>") << '\n';
+    const auto* curType = deviceManager.getCurrentDeviceTypeObject();
+    auto* curDevice = deviceManager.getCurrentAudioDevice();
+
     std::cout << "Current audio device: ";
-    auto* device = deviceManager.getCurrentAudioDevice();
-    if (!device) {
-        std::cout << "No audio device open.\n";
-        return;
+    if (curType == nullptr || curDevice == nullptr) {
+        std::cout << "<none>\n";
+    } else {
+        std::cout << curType->getTypeName()
+                  << " - " << curDevice->getName().quoted() << '\n';
+        std::cout << "Sample rate: "
+                  << curDevice->getCurrentSampleRate() << " Hz\n";
+        std::cout << "Block size: "
+                  << curDevice->getCurrentBufferSizeSamples() << " samples\n";
+        std::cout << "Bit depth: "
+                  << curDevice->getCurrentBitDepth() << '\n';
     }
-    std::cout << device->getName().quoted() << '\n';
-    std::cout << "Sample rate: " << device->getCurrentSampleRate() << " Hz\n";
-    std::cout << "Block size: " << device->getCurrentBufferSizeSamples() << " samples\n";
-    std::cout << "Bit depth: " << device->getCurrentBitDepth() << '\n';
 }
 
 
@@ -79,7 +111,7 @@ int main(int argc, char* argv[])
 
     // Initialize default audio device
     std::cout << "Initialising audio playback device.\n";
-    juce::AudioDeviceManager deviceManager;
+    TestAudioDeviceManager deviceManager;
 
     auto error = deviceManager.initialise (
         0,        // numInputChannelsNeeded

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -54,7 +54,22 @@ void display_device_probe(juce::AudioDeviceManager& deviceManager) {
             std::cout << "  - " << deviceName << std::endl;
         }
     }
-    std::cout << "Discovered " << device_count << " total audio devices.\n";
+    std::cout << "Discovered " << device_count << " total audio devices.\n\n";
+
+    std::cout << "Current audio device type: "
+              << (deviceManager.getCurrentDeviceTypeObject() != nullptr
+                  ? deviceManager.getCurrentDeviceTypeObject()->getTypeName()
+                  : "<none>") << '\n';
+    std::cout << "Current audio device: ";
+    auto* device = deviceManager.getCurrentAudioDevice();
+    if (!device) {
+        std::cout << "No audio device open.\n";
+        return;
+    }
+    std::cout << device->getName().quoted() << '\n';
+    std::cout << "Sample rate: " << device->getCurrentSampleRate() << " Hz\n";
+    std::cout << "Block size: " << device->getCurrentBufferSizeSamples() << " samples\n";
+    std::cout << "Bit depth: " << device->getCurrentBitDepth() << '\n';
 }
 
 


### PR DESCRIPTION
Since the test app is built as a MinGW console app, it won't detect any Windows audio devices. But it will still try, and JUCE normally makes those the default device type, meaning it won't automatically find a default device. To avoid this, we subclass the `AudioDeviceManager` class and override its `createAudioDeviceTypes()` method, avoiding any WASAPI probing at all.

The test app is also enhanced to show the current default device (if one is detected), and to display some parameters about it. Sample output on Linux:
```text
build/src/openshot-audio-demo 
Initialising audio playback device.
Audio device probe results:
Type ALSA:
  - Default ALSA Output (currently PulseAudio Sound Server)
  - PulseAudio Sound Server
  - Default Audio Device
  - PipeWire Sound Server
  - USB Audio Device, USB Audio; Front output / input
  - USB Audio Device, USB Audio; 2.1 Surround output to Front and Subwoofer speakers
  - USB Audio Device, USB Audio; 4.0 Surround output to Front and Rear speakers
  - USB Audio Device, USB Audio; 4.1 Surround output to Front, Rear and Subwoofer speakers
  - USB Audio Device, USB Audio; 5.0 Surround output to Front, Center and Rear speakers
  - USB Audio Device, USB Audio; 5.1 Surround output to Front, Center, Rear and Subwoofer speakers
  - USB Audio Device, USB Audio; 7.1 Surround output to Front, Center, Side, Rear and Woofer speakers
  - USB Audio Device, USB Audio; IEC958 (S/PDIF) Digital Audio Output
  - USB Audio Device, USB Audio #1; IEC958 (S/PDIF) Digital Audio Output
  - HDA Intel PCH, ALC662 rev1 Analog; Front output / input
  - HDA Intel PCH, ALC662 rev1 Analog; 2.1 Surround output to Front and Subwoofer speakers
  - HDA Intel PCH, ALC662 rev1 Analog; 4.0 Surround output to Front and Rear speakers
  - HDA Intel PCH, ALC662 rev1 Analog; 4.1 Surround output to Front, Rear and Subwoofer speakers
  - HDA Intel PCH, ALC662 rev1 Analog; 5.0 Surround output to Front, Center and Rear speakers
  - HDA Intel PCH, ALC662 rev1 Analog; 5.1 Surround output to Front, Center, Rear and Subwoofer speakers
  - HDA Intel PCH, ALC662 rev1 Analog; 7.1 Surround output to Front, Center, Side, Rear and Woofer speakers
  - HDA NVidia, HDMI 0; HDMI Audio Output
  - HDA NVidia, HDMI 1; HDMI Audio Output
  - HDA NVidia, HDMI 2; HDMI Audio Output
  - HDA NVidia, HDMI 3; HDMI Audio Output
  - HDA NVidia, HDMI 4; HDMI Audio Output
Discovered 25 total audio devices.

Current audio device: ALSA - "Default ALSA Output (currently PulseAudio Sound Server)"
Sample rate: 44100 Hz
Block size: 512 samples
Bit depth: 32

You should hear five test tones, precisely 2 seconds apart.
1... 2... 3... 4... 5.
Demo complete. Shutting down device manager.
```

Fixes #130