### PR TITLE
WIP: Release of 0.2.2 (SO still 8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.2.1-dev")
+set(PROJECT_VERSION_FULL "0.2.2")
 set(PROJECT_SO_VERSION 8)
 
 # Remove the dash and anything following, to get the #.#.# version for project()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ endif()
 # (Ruby) have issues dealing with JUCE's use of isFinite()
 target_compile_definitions(openshot-audio INTERFACE HAVE_ISFINITE=1)
 
+# For EXPORTED config
+set(NEED_ASIO FALSE)
 if(WIN32)
   # Try to load ASIO SDK
   find_package(ASIO)


### PR DESCRIPTION
New upstream release of OpenShot Video Editor.

**Change log:**
    - Ensure NEED_ASIO is set
    - Bump version to 0.2.2 (SO still 8)

**Related PRs:**
 - https://github.com/OpenShot/libopenshot/pull/725
 - https://github.com/OpenShot/openshot-qt/pull/4390