### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# A CODEOWNERS file indicates to GitHub which committer(s) should be
+# considered the owners of specific files/subtrees within the repo.
+# Owners will be automatically review-requested on any PR that changes
+# files they own.
+
+/.github/ @ferdnyc
+
+/.gitlab-ci.yml @ferdnyc
+/.gitignore @ferdnyc
+/.gitattributes @ferdnyc
+
+CMakeLists.txt @ferdnyc
+/cmake/ @ferdnyc
+


### PR DESCRIPTION
(I'm opening a similar PR in all three repos, but they all have identical descriptions so if you've read one already, there's nothing new here.)

A GitHub [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) allows repository committers to be associated with certain files or paths within the repo. Whenever a PR is opened that touches one of the files "owned" by a user, that user will automatically receive a review request for the PR. A given file can have multiple "owners", all of whom will receive review requests. 

(`CODEWATCHERS` would really be a better name. Nothing about the association implies actual ownership of the code in question, and nothing about adding `CODEOWNERS` alone has any effect on PRs. The repo _can_ be configured to block PR merges until a certain number of review approvals are submitted by owners of affected files, but that's completely separate from the `CODEOWNERS` file itself. It merely decides who gets asked to review certain PRs, nothing more.)

The file works much like a `.gitignore` file, except instead of just file paths, each is followed by a space-separated list of owners.

I've added myself as a watcher for most of the build configuration and tooling in each of the repos. Any other committers should feel free to associate themselves with any paths they'd like to monitor, as well.

#### Adding additional owners

1. To watch repo file(s), just add or edit a line for the path, and append either your GitHub \@username or the email address you use when committing.

1. Any given _path_ can only have one configuration — child paths override parent paths, and last wins if a path is duplicated. A given file can be matched by more than one path, however.
    * So, if you want to watch the same path as another user, **edit** the existing line and add your ID to the end.
    * Do _not_ **add** an additional line for the same path that only lists your ID, or you will override their existing watch and become that path's sole watcher.

1. Adding lines with fewer watchers _can_ be used to reduce the list inherited from a common parent path. 
    * If you want to watch only part of a common path...
    * Or you _don't_ want to watch a certain subpath...

    Just ensure that a relevant line contains the IDs of other watchers, but not your own.

1. A line with no watchers can be used to disable owners for that path.

#### Examples

If I'm watching `/.github`:
```ini
/.github @ferdnyc
```
 and @jonoomph wants to watch `/.github/stale.yml` only, it would be:
```ini
/.github @ferdnyc
/.github/stale.yml @ferdnyc @jonoomph 
```
If he wanted to watch everything in `/.github` _except_ `/.github/workflows/`:
```ini
/.github @ferdnyc @jonoomph 
/.github/workflows @ferdnyc 
```

#### Unclear behavior

If @jonoomph wanted to watch everything in `/src/` except `/src/Main.cpp`, without disrupting my watch of all `CMakeLists.txt` files, I'm not completely sure what would be necessary. You'd hope that this would work:
```ini
CMakeLists.txt @ferdnyc 
/src/ @jonoomph 
/src/Main.cpp
```
However, [the documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) only says "Order is important; the last matching pattern takes the most precedence." So to preserve my `/src/CMakeLists.txt` watch, it may be necessary to do this:

```ini
CMakeLists.txt @ferdnyc 
/src/ @jonoomph 
/src/Main.cpp
/src/CMakeLists.txt @ferdnyc @jonoomph
```
