### PR TITLE
Bumping version to 0.3.0, SO: 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.2.2-dev")
-set(PROJECT_SO_VERSION 8)
+set(PROJECT_VERSION_FULL "0.3.0")
+set(PROJECT_SO_VERSION 9)
 
 # Remove the dash and anything following, to get the #.#.# version for project()
 string(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")


### PR DESCRIPTION
This is related to the v3.0.0 release of OpenShot Video Editor. This PR is tracking the version # changes related to this release.