### PR TITLE
Revert "Support for New Linux Build Server + glibc Wrapping"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ linux-builder:
     - build/install-x64/*
   script:
     - mkdir -p build; cd build;
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" -DAPPIMAGE_BUILD=1 ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - make -j 2
     - make install
     - PROJECT_VERSION=$(grep -E '^set\(PROJECT_VERSION_FULL "(.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d '")')
@@ -24,7 +24,7 @@ linux-builder:
   except:
   - tags
   tags:
-    - linux-focal
+    - linux-bionic
 
 mac-builder:
   stage: build-libopenshot-audio

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ linux-builder:
   except:
   - tags
   tags:
-    - linux-bionic
+    - linux-focal
 
 mac-builder:
   stage: build-libopenshot-audio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,15 +100,6 @@ include(FeatureSummary)
 ### Build configuration (options)
 option(ENABLE_AUDIO_DOCS "Attempt to build API docs for audio library" ON)
 option(AUTO_INSTALL_DOCS "Include documentation in the default install" ON)
-option(APPIMAGE_BUILD "Build to install in an AppImage (Linux only)" OFF)
-
-if (APPIMAGE_BUILD)
-  # Force older version of glibc and -pthread flag when building AppImage
-  # for better backwards compatibility (i.e older distros)
-  message("Wrapping libc for compatibility with version glibc_2.23")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include /usr/local/include/force_link_glibc_2.23.h -pthread -static-libgcc")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include /usr/local/include/force_link_glibc_2.23.h -pthread -static-libgcc")
-endif()
 
 # Alternative location for JUCE modules (debian has their own)
 set(JUCE_MODULES_PATH "${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode/modules" CACHE PATH


### PR DESCRIPTION
Reverts OpenShot/libopenshot-audio#146

I have reason to believe this change might be responsible for certain crashes in our AppImage. Reverting this for now, to do some testing.

Related to:
- https://github.com/OpenShot/openshot-qt/issues/5181 