### PR TITLE
Release PR for version 0.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-latest]
     steps:
     - uses: actions/checkout@v4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.3.2")
+set(PROJECT_VERSION_FULL "0.3.3")
 set(PROJECT_SO_VERSION 9)
 
 # Remove the dash and anything following, to get the #.#.# version for project()


### PR DESCRIPTION
Bumping version to 0.3.3, SO version remains at 9
*This is part of the OpenShot Video Editor 3.2.0 release.*

Release / Tag: https://github.com/OpenShot/libopenshot-audio/releases/tag/v0.3.3

