### PR TITLE
WIP: Release 0.4.0 for libopenshot-audio (for OpenShot 3.3.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.3.3")
-set(PROJECT_SO_VERSION 9)
+set(PROJECT_VERSION_FULL "0.4.0")
+set(PROJECT_SO_VERSION 10)
 
 #### Set C++ standard level
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Bumping version to 0.4.0 (SO: 10) - new release for OpenShot 3.3.0