### PR TITLE
Updating GitHub actions CI to use Ubuntu 22.04 and 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -31,7 +31,7 @@ jobs:
           popd
 
       # Create an artifact out of the generated HTML
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "OpenShotAudio-docs"
           path: "build/doc/html/"


### PR DESCRIPTION
Fixing an issue with GitHub actions (Ubuntu 20.04 is now depreciated - so moving to 22.04 and 24.04 for our GitHub actions)