### PR TITLE
Integrate SQS into GitLab builds (Auto-Scaling Runners)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,28 @@
 stages:
+  - init-builders
   - build-libopenshot-audio
   - trigger-libopenshot
 
 variables:
   GIT_LOG_FORMAT: "- %h %ad %s [%aN]"
 
+init_linux_builder:
+  stage: init-builders
+  tags:
+    - gitlab-server
+  script:
+    - send-ci-sqs linux
+
+init_windows_builder:
+  stage: init-builders
+  tags:
+    - gitlab-server
+  script:
+    - send-ci-sqs windows
+
 linux-builder:
   stage: build-libopenshot-audio
+  needs: [init_linux_builder]
   artifacts:
     expire_in: 6 months
     paths:
@@ -20,7 +36,9 @@ linux-builder:
     - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
-  when: always
+  after_script:
+    - if [ "$CI" = "true" ]; then sudo shutdown -h now; fi
+  when: on_success
   except:
   - tags
   tags:
@@ -49,6 +67,7 @@ mac-builder:
 
 windows-builder-x64:
   stage: build-libopenshot-audio
+  needs: [init_windows_builder]
   artifacts:
     expire_in: 6 months
     paths:
@@ -65,7 +84,9 @@ windows-builder-x64:
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$CI_PIPELINE_ID`nVERSION:$PROJECT_VERSION`nSO:$PROJECT_SO" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-  when: always
+  after_script:
+    - if ($env:CI -eq "true") { shutdown /s /t 0 }
+  when: on_success
   except:
   - tags
   tags:
@@ -73,6 +94,7 @@ windows-builder-x64:
 
 windows-builder-x86:
   stage: build-libopenshot-audio
+  needs: [init_windows_builder]
   artifacts:
     expire_in: 6 months
     paths:
@@ -89,7 +111,9 @@ windows-builder-x86:
     - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$CI_PIPELINE_ID`nVERSION:$PROJECT_VERSION`nSO:$PROJECT_SO" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
-  when: always
+  after_script:
+    - if ($env:CI -eq "true") { shutdown /s /t 0 }
+  when: on_success
   except:
   - tags
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,19 +102,6 @@ windows-builder-x86:
   tags:
     - windows
 
-# CLEANUP: Always run, removes both messages, then sleeps
-cleanup_builders:
-  stage: cleanup-builders
-  except:
-    - tags
-  tags: [gitlab]
-  script:
-    - receive-ci-sqs linux
-    - receive-ci-sqs windows
-    - echo "Pausing for ASG to scale-down..."
-    - sleep 60
-  when: always
-
 # TRIGGER: Only runs if all previous succeeded
 trigger-pipeline:
   stage: trigger-libopenshot

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ init_builders:
   stage: init-builders
   except:
     - tags
-  tags: [gitlab-server]
+  tags: [gitlab]
   script:
     - send-ci-sqs linux
     - send-ci-sqs windows
@@ -124,4 +124,4 @@ trigger-pipeline:
   dependencies: []
   except:
   - tags
-  tags: [gitlab-server]
+  tags: [gitlab]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,34 +1,32 @@
 stages:
   - init-builders
   - build-libopenshot-audio
+  - cleanup-builders
   - trigger-libopenshot
 
 variables:
   GIT_LOG_FORMAT: "- %h %ad %s [%aN]"
 
-init_linux_builder:
+# INIT BUILDERS: Add to both queues in one job
+init_builders:
   stage: init-builders
-  tags:
-    - gitlab-server
+  except:
+    - tags
+  tags: [gitlab-server]
   script:
     - send-ci-sqs linux
-
-init_windows_builder:
-  stage: init-builders
-  tags:
-    - gitlab-server
-  script:
     - send-ci-sqs windows
 
+# BUILD STAGE: All build jobs depend on init_builders
 linux-builder:
   stage: build-libopenshot-audio
-  needs: [init_linux_builder]
   artifacts:
     expire_in: 6 months
     paths:
     - build/install-x64/*
   script:
-    - mkdir -p build; cd build;
+    - mkdir -p build
+    - cd build
     - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - make -j 2
     - make install
@@ -36,13 +34,9 @@ linux-builder:
     - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
-  after_script:
-    - if [ "$CI" = "true" ]; then sudo shutdown -h now; fi
-  when: on_success
   except:
-  - tags
-  tags:
-    - linux-focal
+    - tags
+  tags: [linux-focal]
 
 mac-builder:
   stage: build-libopenshot-audio
@@ -59,15 +53,12 @@ mac-builder:
     - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' CMakeLists.txt | awk '{print $2}' | tr -d ')')
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "build/install-x64/share/$CI_PROJECT_NAME.env"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-  when: always
   except:
-  - tags
-  tags:
-    - mac
+    - tags
+  tags: [mac]
 
 windows-builder-x64:
   stage: build-libopenshot-audio
-  needs: [init_windows_builder]
   artifacts:
     expire_in: 6 months
     paths:
@@ -84,17 +75,12 @@ windows-builder-x64:
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$CI_PIPELINE_ID`nVERSION:$PROJECT_VERSION`nSO:$PROJECT_SO" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-  after_script:
-    - if ($env:CI -eq "true") { shutdown /s /t 0 }
-  when: on_success
   except:
-  - tags
-  tags:
-    - windows
+    - tags
+  tags: [windows]
 
 windows-builder-x86:
   stage: build-libopenshot-audio
-  needs: [init_windows_builder]
   artifacts:
     expire_in: 6 months
     paths:
@@ -111,14 +97,25 @@ windows-builder-x86:
     - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$CI_PIPELINE_ID`nVERSION:$PROJECT_VERSION`nSO:$PROJECT_SO" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
-  after_script:
-    - if ($env:CI -eq "true") { shutdown /s /t 0 }
-  when: on_success
   except:
   - tags
   tags:
     - windows
 
+# CLEANUP: Always run, removes both messages, then sleeps
+cleanup_builders:
+  stage: cleanup-builders
+  except:
+    - tags
+  tags: [gitlab-server]
+  script:
+    - receive-ci-sqs linux
+    - receive-ci-sqs windows
+    - echo "Pausing for ASG to scale-down..."
+    - sleep 60
+  when: always
+
+# TRIGGER: Only runs if all previous succeeded
 trigger-pipeline:
   stage: trigger-libopenshot
   script:
@@ -127,5 +124,4 @@ trigger-pipeline:
   dependencies: []
   except:
   - tags
-  tags:
-    - linux
+  tags: [gitlab-server]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ cleanup_builders:
   stage: cleanup-builders
   except:
     - tags
-  tags: [gitlab-server]
+  tags: [gitlab]
   script:
     - receive-ci-sqs linux
     - receive-ci-sqs windows


### PR DESCRIPTION
In an effort to save on infrastructure costs, switching to a dynamic, SQS-based, Auto-Scaling GitLab runner design, which will only run our builders when we need them to run. It should save a few hundred dollars a month.