### PR TITLE
Fix musl compilation error related to LFS64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,11 @@ if(APPLE)
     -flax-vector-conversions)
 endif()
 
+# Enforce LFS64 in glibc.
+if(UNIX AND NOT APPLE)
+  target_compile_definitions(openshot-audio PUBLIC _FILE_OFFSET_BITS=64)
+endif()
+
 # ALSA (Linux only)
 if(UNIX AND NOT APPLE)
   set(NEED_ALSA TRUE)

--- a/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h
+++ b/JuceLibraryCode/modules/juce_core/native/juce_SharedCode_posix.h
@@ -166,7 +166,7 @@ int juce_siginterrupt ([[maybe_unused]] int sig, [[maybe_unused]] int flag)
 //==============================================================================
 namespace
 {
-   #if JUCE_LINUX || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
+   #if JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T) // (this iOS stuff is to avoid a simulator bug)
     using juce_statStruct = struct stat64;
     #define JUCE_STAT  stat64
    #else


### PR DESCRIPTION
I am a Void Linux packager trying to update our openshot. This PR aims to improve musl libc support, which is currently suboptimal in the codebase.

LFS64 interfaces are deprecated in musl, since they are not needed there. See notes for musl-1.2.4.tar.gz in https://musl.libc.org/releases.html and also https://wiki.gentoo.org/wiki/Musl_porting_notes#error:_LFS64_interfaces_.28.2A64_undeclared_here.2C_ex._pread64.29.

The `juce_statStruct` type definition and several other things depending on it appear to be a part of libopenshot-audio's public API, so I set `_FILE_OFFSET_BITS=64` as `PUBLIC`. These changes should be fully API/ABI compatible with the previous version.

I did rudimentary ABI breakage testing with [abi-compliance-checker](https://github.com/lvc/abi-compliance-checker) on x86_64 glibc (which worked as expected, since 64bit architectures were never affected by LFS64 if I understand it correctly) and on i686 glibc. I didn't test on musl, because it also was never affected by LFS64, since it never provided 32bit filesystem types. Everything reported 100% binary and source compatibility.

Void Linux applies additional patches to improve musl support, but I am not as familiar with them (I authored the changes in this PR, the other patches are older and I've only ported them to a newer version of libopenshot-audio). I might make a pull request for these too after I study them more.