### PR TITLE
Remove dead "-framework AGL" link directive (macOS 10.14+ and all Apple Silicon)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,6 @@ if(APPLE)
     "-framework CoreAudio"
     "-framework CoreMidi"
     "-framework IOKit"
-    "-framework AGL"
     "-framework AudioToolbox"
     "-framework QuartzCore"
     "-framework Accelerate"


### PR DESCRIPTION
The `APPLE` branch of `CMakeLists.txt` links the `AGL` framework:

```cmake
if(APPLE)
  ...
  target_link_libraries(openshot-audio PRIVATE
    ...
    "-framework IOKit"
    "-framework AGL"
    "-framework AudioToolbox"
    ...
  )
```

`AGL` (Apple Graphics Library) was deprecated long ago and **has been
absent from the macOS SDK since macOS 10.14 Mojave (2018)**, so on any
reasonably modern Xcode or Command Line Tools the link step fails with:

```
ld: framework 'AGL' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libopenshot-audio.0.6.0.dylib] Error 1
```

That includes every Apple Silicon machine, since Apple Silicon only supports
macOS 11+, so the project cannot currently be built from source on any
M1/M2/M3 Mac without patching this file.

`AGL` is not actually used by `libopenshot-audio` at runtime: it appears to
have been inherited from an old JUCE integration example, and modern macOS
acquires its OpenGL context through Cocoa (`NSOpenGLContext`) rather than
`AGL`. Removing the link directive has no behavioural effect beyond letting
the library link successfully.

### Verification

Verified on an Apple Silicon (arm64) Mac:

* OS: macOS 15
* Toolchain: AppleClang 17.0.0, CMake 4.0.3, Command Line Tools installed
* Steps: `cmake -B build -S . && cmake --build build -j`
* Result with this patch: `openshot-audio.dylib` and
  `openshot-audio-demo` both build and link successfully. Without the
  patch, link fails at `openshot-audio.dylib` with the error above.

### Scope

Intentionally minimal: one line removed, no behavioural changes, no other
framework list edits. Happy to follow up with a small macOS build section
in `INSTALL.md` in a separate PR if useful, since the current instructions
are headed "Linux Build Instructions" and don't document the macOS path.

### Context

This is my first PR to libopenshot-audio. It is part of a small series of
Apple Silicon contributor fixes: [openshot-qt#6003](https://github.com/OpenShot/openshot-qt/pull/6003),
[#6004](https://github.com/OpenShot/openshot-qt/pull/6004),
[#6005](https://github.com/OpenShot/openshot-qt/pull/6005), and
[#6006](https://github.com/OpenShot/openshot-qt/pull/6006) cover the
packaging-side changes needed before an arm64 DMG can be produced; this PR
is the first of the corresponding libopenshot-side fixes and also resolves
the root cause of [libopenshot#1030](https://github.com/OpenShot/libopenshot/issues/1030),
whose reporter hit the follow-on "cannot find OpenShotAudio" CMake error
because libopenshot-audio cannot be built on their machine in the first place.