### PR TITLE
Add native Windows Arm64 audio build readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,48 @@ jobs:
         pushd build
         cmake --build . --target install -- VERBOSE=1
         popd
+
+  # Supplemental native Arm64 presubmit. Its output is never a release
+  # artifact; GitLab remains the production artifact chain.
+  build-arm64-presubmit:
+    runs-on: windows-11-arm
+    continue-on-error: true
+    steps:
+    - name: Preserve repository line endings
+      run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@v4
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        # Intentionally refresh repository metadata. The subsequent exact
+        # lock verification fails on version drift until maintainers refresh
+        # the lock or provide the G1 signed snapshot.
+        update: true
+
+    - name: Install exact CLANGARM64 package versions
+      shell: msys2 {0}
+      run: |
+        mapfile -t packages < <(sed -n '/^[^#[:space:]][^=]*=/s/,[^,]*$//p' ci/windows-arm64-packages.lock)
+        pacman --noconfirm -S --needed -- "${packages[@]}"
+
+    - name: Build libopenshot-audio (CLANGARM64, presubmit only)
+      shell: msys2 {0}
+      run: |
+        cmake -B build -S . -G Ninja \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_INSTALL_PREFIX="$PWD/dist-arm64" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DENABLE_AUDIO_DOCS=OFF
+        cmake --build build
+        ctest --test-dir build --output-on-failure -VV
+        cmake --install build
+        python -m unittest discover -s ci -p "test_*.py" -v
+        python ci/validate_arm64_architecture.py \
+          --require-native-arm64 \
+          --package-lock ci/windows-arm64-packages.lock \
+          --payload-root dist-arm64 \
+          --require-payload \
+          --json-report build/arm64-presubmit-report.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,46 @@ windows-builder-x64:
     - tags
   tags: [windows]
 
+# WINDOWS ARM64 (native, additive lane; existing x64/x86 jobs are unchanged).
+# Contract identity: windows-arm64-clangarm64-v1 (design-spec.md).
+# Verifies the shared ci/windows-arm64-packages.lock and validates every
+# produced .exe/.dll/.pyd, plus the native-process oracle of the build host,
+# using ci/validate_arm64_architecture.py (design-amendment-A1 semantics:
+# native execution requires pProcessMachine == IMAGE_FILE_MACHINE_UNKNOWN
+# and pNativeMachine == IMAGE_FILE_MACHINE_ARM64; every payload PE must be
+# machine 0xAA64 independently).
+windows-builder-arm64:
+  stage: build-libopenshot-audio
+  artifacts:
+    expire_in: 6 months
+    paths:
+    - build/install-arm64/
+    - build\arm64-architecture-report.json
+  script:
+    - $env:Path = "C:\msys64\clangarm64\bin;C:\msys64\usr\bin;" + $env:Path;
+    - $env:MSYSTEM = "CLANGARM64"
+    - New-Item -ItemType Directory -Force -Path build
+    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=build/install-arm64" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -D"CMAKE_BUILD_TYPE:STRING=Release"
+    - cmake --build build
+    - ctest --test-dir build --output-on-failure -VV
+    - cmake --install build
+    - python -m unittest discover -s ci -p "test_*.py" -v
+    - python ci\validate_arm64_architecture.py --require-native-arm64 --package-lock ci\windows-arm64-packages.lock --payload-root build\install-arm64 --require-payload --json-report build\arm64-architecture-report.json
+    - $PROJECT_VERSION = (Select-String -Path "CMakeLists.txt" -Pattern '^set\(PROJECT_VERSION_FULL "(.*)\"' | %{$_.Matches.Groups[1].value})
+    - $PROJECT_SO = (Select-String -Path "CMakeLists.txt" -Pattern '^set\(PROJECT_SO_VERSION (.*)\)' | %{$_.Matches.Groups[1].value})
+    - New-Item -path "build/install-arm64/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$CI_PIPELINE_ID`nVERSION:$PROJECT_VERSION`nSO:$PROJECT_SO`nTARGET_TRIPLET:aarch64-w64-mingw32`nPE_MACHINE:0xAA64" -ItemType file -force
+    - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
+    - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-arm64/share/$CI_PROJECT_NAME.log"
+  rules:
+    - if: '$ENABLE_WINDOWS_ARM64 == "1" && $CI_COMMIT_TAG == null'
+    - when: never
+  tags: [windows-arm64]
+  # Requires release infrastructure's native/virtual Windows Arm64 GitLab
+  # runner tagged windows-arm64 (design-spec.md "Release-infrastructure
+  # surface"). Until that runner exists, this job cannot execute; it does
+  # not weaken or replace the existing windows-builder-x64/x86 jobs.
+  allow_failure: true
+
 windows-builder-x86:
   stage: build-libopenshot-audio
   artifacts:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ if(WIN32)
   if(TARGET ASIO::SDK)
     target_link_libraries(openshot-audio PRIVATE ASIO::SDK)
     set(NEED_ASIO TRUE)
+  else()
+    target_compile_definitions(openshot-audio PUBLIC JUCE_ASIO=0)
   endif()
   # Order here can be important!
   # For example, winmm.lib must come before kernel32.lib (if linked)

--- a/ci/test_validate_arm64_architecture.py
+++ b/ci/test_validate_arm64_architecture.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import contextlib
+import importlib.util
+import io
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+VALIDATOR_PATH = os.path.join(os.path.dirname(__file__), "validate_arm64_architecture.py")
+SPEC = importlib.util.spec_from_file_location("validate_arm64_architecture", VALIDATOR_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load validator from %s" % VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+def write_pe(path, machine):
+    data = bytearray(0x80)
+    data[:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, 0x40)
+    data[0x40:0x44] = b"PE\0\0"
+    struct.pack_into("<H", data, 0x44, machine)
+    with open(path, "wb") as stream:
+        stream.write(data)
+
+
+class Arm64ArchitectureValidatorTests(unittest.TestCase):
+    def test_package_lock_reports_missing_file(self):
+        verified, failures = validator.verify_package_lock("missing-package-lock.txt")
+        self.assertEqual(verified, [])
+        self.assertIn("Unable to read package lock", failures[0])
+
+    def test_payload_scan_accepts_arm64_and_rejects_amd64(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_pe(os.path.join(root, "native.dll"), validator.IMAGE_FILE_MACHINE_ARM64)
+            results, failures = validator.scan_payload_architecture(root)
+            self.assertEqual(len(results), 1)
+            self.assertEqual(failures, [])
+
+            write_pe(os.path.join(root, "foreign.pyd"), validator.IMAGE_FILE_MACHINE_AMD64)
+            results, failures = validator.scan_payload_architecture(root)
+            self.assertEqual(len(results), 2)
+            self.assertEqual(len(failures), 1)
+
+    def test_required_native_host_fails_closed(self):
+        oracle = {
+            "checked": True,
+            "process_machine": validator.IMAGE_FILE_MACHINE_UNKNOWN,
+            "native_machine": validator.IMAGE_FILE_MACHINE_AMD64,
+            "is_wow_or_emulated": False,
+            "native_arm64_ok": False,
+            "reason": None,
+        }
+        with mock.patch.object(validator, "read_native_process_oracle", return_value=oracle):
+            with mock.patch.object(sys, "argv", ["validator", "--require-native-arm64"]):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.assertEqual(validator.main(), 1)
+
+    def test_package_lock_detects_version_drift(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="example-package 1.2.4\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified[0]["version"], "1.2.4")
+            self.assertEqual(len(failures), 1)
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_reports_missing_pacman(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            with mock.patch.object(
+                validator.subprocess, "run", side_effect=FileNotFoundError("pacman")
+            ):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertIn("Unable to run pacman", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_reports_malformed_entry(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("malformed-entry\n")
+            lock_path = lock.name
+        try:
+            verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertEqual(failures, ["Malformed package lock entry: malformed-entry"])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unsafe_package_name(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("-unsafe=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertEqual(failures, ["Invalid package name in lock: '-unsafe'"])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unexpected_pacman_output(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="warning only\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertIn("Unexpected pacman output", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unverified_real_hash(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,abc123\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="example-package 1.2.3\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                _verified, failures = validator.verify_package_lock(lock_path)
+            self.assertIn("hash verification is not implemented", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_require_payload_rejects_missing_root(self):
+        with mock.patch.object(sys, "argv", ["validator", "--require-payload"]):
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(validator.main(), 1)
+
+    def test_require_payload_rejects_directory_without_valid_pe(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "stub.exe"), "w", encoding="utf-8") as stream:
+                stream.write("not a PE")
+            with mock.patch.object(
+                sys, "argv", ["validator", "--payload-root", root, "--require-payload"]
+            ):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.assertEqual(validator.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/validate_arm64_architecture.py
+++ b/ci/validate_arm64_architecture.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""
+@file
+@brief Reusable Windows Arm64 architecture validator (design-spec.md
+       G2/G3/G8/G11) implementing design-amendment-A1 native-process
+       semantics.
+
+This script is shared, byte-for-byte, across libopenshot-audio (PR A),
+libopenshot (PR B), and openshot-qt (PR C). It performs two independent
+checks, exactly as required by design-amendment-A1:
+
+1. Native-process oracle (host evidence): calls IsWow64Process2 via ctypes on
+   the *currently running* Python process and asserts
+     - pNativeMachine == IMAGE_FILE_MACHINE_ARM64 (0xAA64)
+     - pProcessMachine == IMAGE_FILE_MACHINE_UNKNOWN (0x0)
+   Any nonzero pProcessMachine is WOW/emulated execution and fails this
+   check. This check only passes evidence when actually run under a native
+   Arm64 Python interpreter; on any other host it reports the real, honest
+   values it observed and does not fabricate a pass.
+
+2. Recursive static PE architecture scan (payload evidence): recursively
+   scans a given root directory for every .exe, .dll, and .pyd, reads the
+   COFF file header "Machine" field directly (no external tool dependency),
+   and asserts every one of them is IMAGE_FILE_MACHINE_ARM64 (0xAA64). This
+   check is independent of the host architecture and can run on any Python
+   3 interpreter, including this AMD64 documentation/implementation
+   workspace, against whatever candidate payload directory is supplied.
+
+The two checks are deliberately independent, per design-amendment-A1: a
+native process oracle failure does not imply a payload architecture
+failure, and vice versa. Callers (CI jobs) should run both and fail closed
+if either reports a problem, unless the repository/job intentionally only
+has one kind of evidence available (e.g. no payload directory yet).
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import re
+import subprocess
+import struct
+import sys
+
+IMAGE_FILE_MACHINE_UNKNOWN = 0x0
+IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+IMAGE_FILE_MACHINE_AMD64 = 0x8664
+IMAGE_FILE_MACHINE_I386 = 0x14C
+
+MACHINE_NAMES = {
+    IMAGE_FILE_MACHINE_UNKNOWN: "UNKNOWN (native, non-WOW64)",
+    IMAGE_FILE_MACHINE_ARM64: "ARM64",
+    IMAGE_FILE_MACHINE_AMD64: "AMD64",
+    IMAGE_FILE_MACHINE_I386: "I386",
+}
+
+
+def machine_name(value):
+    return MACHINE_NAMES.get(value, "0x%04X" % value)
+
+
+def read_native_process_oracle():
+    """
+    Query IsWow64Process2 for the current process. Returns a dict with the
+    exact observed pProcessMachine / pNativeMachine values, the derived
+    WOW/emulation state, and a pass/fail verdict against
+    design-amendment-A1's native-execution requirement.
+    """
+    result = {
+        "checked": False,
+        "process_machine": None,
+        "native_machine": None,
+        "is_wow_or_emulated": None,
+        "native_arm64_ok": False,
+        "reason": None,
+    }
+
+    if not sys.platform.startswith("win"):
+        result["reason"] = "IsWow64Process2 is a Windows-only API; not running on Windows."
+        return result
+
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+        is_wow64_process2 = getattr(kernel32, "IsWow64Process2", None)
+        if is_wow64_process2 is None:
+            result["reason"] = "IsWow64Process2 is unavailable on this Windows system."
+            return result
+        is_wow64_process2.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_ushort),
+            ctypes.POINTER(ctypes.c_ushort),
+        ]
+        is_wow64_process2.restype = ctypes.c_int
+        process_machine = ctypes.c_ushort(0)
+        native_machine = ctypes.c_ushort(0)
+        handle = kernel32.GetCurrentProcess()
+        ok = is_wow64_process2(
+            handle,
+            ctypes.byref(process_machine),
+            ctypes.byref(native_machine),
+        )
+        if not ok:
+            result["reason"] = (
+                "IsWow64Process2 returned failure (GetLastError=%s)."
+                % ctypes.get_last_error()
+            )
+            return result
+
+        result["checked"] = True
+        result["process_machine"] = process_machine.value
+        result["native_machine"] = native_machine.value
+        result["is_wow_or_emulated"] = process_machine.value != IMAGE_FILE_MACHINE_UNKNOWN
+        result["native_arm64_ok"] = (
+            native_machine.value == IMAGE_FILE_MACHINE_ARM64
+            and process_machine.value == IMAGE_FILE_MACHINE_UNKNOWN
+        )
+        return result
+    except Exception as exc:  # noqa: BLE001 - report, don't hide
+        result["reason"] = "IsWow64Process2 call failed: %r" % exc
+        return result
+
+
+def read_pe_machine(path):
+    """
+    Read the COFF "Machine" field directly from a PE file's file header,
+    without requiring llvm-readobj/dumpbin/objdump. Returns an int machine
+    value, or None if the file is not a valid PE (e.g. a script stub).
+    """
+    with open(path, "rb") as f:
+        dos_header = f.read(64)
+        if len(dos_header) < 64 or dos_header[0:2] != b"MZ":
+            return None
+        pe_offset = struct.unpack_from("<I", dos_header, 0x3C)[0]
+        f.seek(pe_offset)
+        pe_sig = f.read(4)
+        if pe_sig != b"PE\x00\x00":
+            return None
+        coff_header = f.read(20)
+        if len(coff_header) < 20:
+            return None
+        machine = struct.unpack_from("<H", coff_header, 0)[0]
+        return machine
+
+
+def scan_payload_architecture(root):
+    """
+    Recursively scan `root` for .exe/.dll/.pyd files and read each PE
+    Machine field. Returns (results, failures) where results is a list of
+    {"path", "machine", "machine_name"} and failures is a list of
+    human-readable problem strings (missing PE header, wrong architecture).
+    """
+    results = []
+    failures = []
+    if not os.path.isdir(root):
+        failures.append("Payload root does not exist: %s" % root)
+        return results, failures
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            ext = os.path.splitext(filename)[1].lower()
+            if ext not in (".exe", ".dll", ".pyd"):
+                continue
+            full_path = os.path.join(dirpath, filename)
+            try:
+                machine = read_pe_machine(full_path)
+            except OSError as exc:
+                failures.append("Could not read %s: %s" % (full_path, exc))
+                continue
+
+            if machine is None:
+                failures.append("Not a valid PE file (no MZ/PE header): %s" % full_path)
+                continue
+
+            results.append({
+                "path": full_path,
+                "machine": machine,
+                "machine_name": machine_name(machine),
+            })
+            if machine != IMAGE_FILE_MACHINE_ARM64:
+                failures.append(
+                    "Wrong architecture %s (expected ARM64/0xAA64): %s"
+                    % (machine_name(machine), full_path)
+                )
+
+    return results, failures
+
+
+def verify_package_lock(path):
+    failures = []
+    verified = []
+    try:
+        with open(path, encoding="utf-8") as stream:
+            entries = [
+                line.strip()
+                for line in stream
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+    except OSError as exc:
+        return verified, ["Unable to read package lock %s: %s" % (path, exc)]
+    for entry in entries:
+        if "=" not in entry or "," not in entry.split("=", 1)[1]:
+            failures.append("Malformed package lock entry: %s" % entry)
+            continue
+        package, remainder = entry.split("=", 1)
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9@._+:-]*", package):
+            failures.append("Invalid package name in lock: %r" % package)
+            continue
+        expected_version, expected_sha256 = (
+            value.strip() for value in remainder.split(",", 1)
+        )
+        if expected_sha256 != "UNVERIFIED-NO-SIGNED-SNAPSHOT":
+            failures.append(
+                "Package archive hash verification is not implemented for %s: %s"
+                % (package, expected_sha256)
+            )
+        try:
+            completed = subprocess.run(
+                ["pacman", "-Q", "--", package],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            failures.append("Unable to run pacman for %s: %s" % (package, exc))
+            continue
+        if completed.returncode != 0:
+            failures.append("Package not installed: %s" % package)
+            continue
+        lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+        fields = lines[0].split() if lines else []
+        if len(fields) != 2 or fields[0] != package:
+            failures.append(
+                "Unexpected pacman output for %s: %r" % (package, completed.stdout)
+            )
+            continue
+        actual_version = fields[1]
+        verified.append({
+            "package": package,
+            "version": actual_version,
+            "expected_version": expected_version,
+            "expected_sha256": expected_sha256,
+        })
+        if actual_version != expected_version:
+            failures.append(
+                "Wrong package version for %s: %s (expected %s)"
+                % (package, actual_version, expected_version)
+            )
+    return verified, failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload-root",
+        default=None,
+        help="Directory to recursively scan for .exe/.dll/.pyd PE architecture. "
+             "If omitted, only the native-process oracle check runs.",
+    )
+    parser.add_argument(
+        "--require-payload",
+        action="store_true",
+        help="Fail if --payload-root is omitted or contains no valid PE candidate files.",
+    )
+    parser.add_argument(
+        "--require-native-arm64",
+        action="store_true",
+        help="Fail unless the current process is running natively on Windows Arm64.",
+    )
+    parser.add_argument(
+        "--json-report",
+        default=None,
+        help="Optional path to write the full machine-readable report.",
+    )
+    parser.add_argument(
+        "--package-lock",
+        default=None,
+        help="Verify installed pacman package versions against this lock file.",
+    )
+    args = parser.parse_args()
+
+    oracle = read_native_process_oracle()
+
+    payload_results = []
+    payload_failures = []
+    if args.payload_root:
+        payload_results, payload_failures = scan_payload_architecture(args.payload_root)
+        if args.require_payload and not payload_results:
+            payload_failures.append(
+                "No valid PE .exe/.dll/.pyd files were scanned under: %s" % args.payload_root
+            )
+    elif args.require_payload:
+        payload_failures.append("--require-payload was set but --payload-root was not provided.")
+
+    package_results = []
+    package_failures = []
+    if args.package_lock:
+        package_results, package_failures = verify_package_lock(args.package_lock)
+
+    report = {
+        "contract": "windows-arm64-clangarm64-v1",
+        "amendment": "A1",
+        "native_process_oracle": oracle,
+        "native_process_required": args.require_native_arm64,
+        "payload_root": args.payload_root,
+        "payload_files_scanned": len(payload_results),
+        "payload_failures": payload_failures,
+        "payload_results": payload_results,
+        "package_lock": args.package_lock,
+        "package_results": package_results,
+        "package_failures": package_failures,
+    }
+
+    print("== Native Arm64 process oracle (design-amendment-A1) ==")
+    if oracle["checked"]:
+        print("  process_machine = %s" % machine_name(oracle["process_machine"]))
+        print("  native_machine  = %s" % machine_name(oracle["native_machine"]))
+        print("  wow/emulated    = %s" % oracle["is_wow_or_emulated"])
+        print("  native ARM64 ok = %s" % oracle["native_arm64_ok"])
+    else:
+        print("  NOT AVAILABLE: %s" % oracle["reason"])
+
+    print("== Recursive payload PE architecture scan ==")
+    if args.payload_root:
+        print("  root = %s" % args.payload_root)
+        print("  files scanned = %d" % len(payload_results))
+        for failure in payload_failures:
+            print("  FAIL: %s" % failure)
+    else:
+        print("  SKIPPED: no --payload-root supplied")
+
+    print("== MSYS2 package lock ==")
+    if args.package_lock:
+        print("  lock = %s" % args.package_lock)
+        print("  packages verified = %d" % len(package_results))
+        for failure in package_failures:
+            print("  FAIL: %s" % failure)
+    else:
+        print("  SKIPPED: no --package-lock supplied")
+
+    if args.json_report:
+        with open(args.json_report, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.require_native_arm64 and not oracle["native_arm64_ok"]:
+        reason = oracle["reason"] or (
+            "observed process_machine=%s, native_machine=%s"
+            % (
+                machine_name(oracle["process_machine"]),
+                machine_name(oracle["native_machine"]),
+            )
+        )
+        print("RESULT: FAIL (native Windows Arm64 process required: %s)" % reason)
+        return 1
+
+    if payload_failures:
+        print("RESULT: FAIL (%d payload architecture problem(s))" % len(payload_failures))
+        return 1
+    if package_failures:
+        print("RESULT: FAIL (%d package lock problem(s))" % len(package_failures))
+        return 1
+
+    print("RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/windows-arm64-packages.lock
+++ b/ci/windows-arm64-packages.lock
@@ -1,0 +1,45 @@
+# Windows Arm64 MSYS2 CLANGARM64 package/provenance lock
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Contract identity: windows-arm64-clangarm64-v1
+# Target: Windows 11 Arm64, PE/COFF Machine=ARM64 (0xAA64)
+# Environment: MSYS2 CLANGARM64 at C:\msys64\clangarm64, aarch64-w64-mingw32
+#
+# This file pins the exact MSYS2 CLANGARM64 package set/versions required to
+# build libopenshot-audio (and, transitively, libopenshot and openshot-qt) for
+# the native Windows Arm64 lane. It is consumed unchanged by PR A, PR B, and
+# PR C so that all three producer artifacts share one dependency snapshot.
+#
+# Populate the sha256 column from the signed MSYS2 CLANGARM64 repo database
+# (repo.db.sig) once release infrastructure publishes the mirrored/pinned
+# snapshot required by design-spec.md G1. Until that snapshot exists, this
+# lock records the exact package/version identity only; the sha256 column is
+# intentionally left as UNVERIFIED-NO-SIGNED-SNAPSHOT so no producer job can
+# silently claim checksum verification that has not actually happened.
+#
+# name=version-release,sha256
+mingw-w64-clang-aarch64-clang=22.1.8-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-libc++=22.1.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-compiler-rt=22.1.8-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-llvm-openmp=22.1.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-libwinpthread=14.0.0.r302.gd7f3c5201-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-cmake=4.4.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-ninja=1.13.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-swig=4.5.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python=3.14.7-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python-pyqt6=6.11.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python-pyqt6-sip=13.12.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-base=6.11.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-svg=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-multimedia=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-imageformats=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-ffmpeg=9.0.1-3,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-opencv=5.0.0-3,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-protobuf=35.1-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-zeromq=4.3.5-5,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-cppzmq=4.11.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-babl=0.1.128-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-imagemagick=7.1.2.30-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-jsoncpp=1.9.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-zlib=1.3.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT


### PR DESCRIPTION
## Scope: Windows Arm64 pre-action readiness

This PR adds the native Arm64 build foundation for OpenShotAudio. It does **not** attempt upstream signing, publication, or release ownership.

### Changes
- native CLANGARM64 GitLab lane and GitHub-hosted `windows-11-arm` presubmit
- fail-closed native-host and PE payload architecture validation
- exact package/version lock validation
- optional-ASIO handling (`JUCE_ASIO=0` when the SDK is unavailable) while retaining WASAPI

### Evidence
- hosted native Windows Arm64 build/test/install/architecture workflow passed
- validator tests pass
- existing non-Arm lanes remain intact

### Dependency order
This is PR A. OpenShot/libopenshot#1089 consumes its Arm64 artifact.

### Post-actions owned by maintainers
Production GitLab runner registration, signing, release publication, and official support announcement.

AI assistance disclosure: implementation and review used GitHub Copilot CLI.