### PR TITLE
Fix macOS framework name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ if(APPLE)
     "-framework Cocoa"
     "-framework CoreFoundation"
     "-framework CoreAudio"
-    "-framework CoreMidi"
+    "-framework CoreMIDI"
     "-framework IOKit"
     "-framework AGL"
     "-framework AudioToolbox"


### PR DESCRIPTION
This fixes building on case-sensitive file systems.